### PR TITLE
Add "Using remote repositories" option to turn off remote related settings

### DIFF
--- a/app/views/repositories/_form.html.erb
+++ b/app/views/repositories/_form.html.erb
@@ -14,22 +14,25 @@
 
 
 
-
-<% if Setting.plugin_gitdownload["git_auto_create_repo"] == 'on' &&  params[:action] != 'edit' %>
-    <p id="create_repo"><%= f.check_box :create_repo, :label => :field_repository_create, :checked => true %></p>
-<% else %>
-    <p id="create_repo"><%= f.check_box :create_repo, :label => :field_repository_create %></p>    
+<% if Setting.plugin_gitdownload["git_repo_is_remote"] == 'on' %>
+    <% if Setting.plugin_gitdownload["git_auto_create_repo"] == 'on' &&  params[:action] != 'edit' %>
+        <p id="create_repo"><%= f.check_box :create_repo, :label => :field_repository_create, :checked => true %></p>
+    <% else %>
+        <p id="create_repo"><%= f.check_box :create_repo, :label => :field_repository_create %></p>
+    <% end %>
 <% end %>
 
 <p>
-    
+
 <%= f.text_field :identifier, :disabled => @repository.identifier_frozen?, :required => true %>
 <% unless @repository.identifier_frozen? %>
   <em class="info">
     <%= l(:text_length_between, :min => 1, :max => Repository::IDENTIFIER_MAX_LENGTH) %> <%= l(:text_repository_identifier_info).html_safe %>
-    <span id="gitdownload-info" class="gitdownload-info">
-        Changing "<%= l(:field_path_to_repository) %>" will break git-http-backend authentication
-    </span>
+      <% if Setting.plugin_gitdownload["git_repo_is_remote"] == 'on' %>
+        <span id="gitdownload-info" class="gitdownload-info">
+            Changing "<%= l(:field_path_to_repository) %>" will break git-http-backend authentication
+        </span>
+      <% end %>
   </em>
 <% end %>
 </p>
@@ -42,21 +45,23 @@
 </div>
 
 
-<% if params[:action] != 'edit' %>
-    <script type="text/javascript">
+<% if Setting.plugin_gitdownload["git_repo_is_remote"] == 'on' %>
+    <% if params[:action] != 'edit' %>
+        <script type="text/javascript">
+
+            var path = "<%= Setting.plugin_gitdownload["git_repo_create_path"] %>/<%= @project.identifier %>.";
+            var path = path.replace('//', '/');
+            var suffix = ".git";
         
-        var path = "<%= Setting.plugin_gitdownload["git_repo_create_path"] %>/<%= @project.identifier %>.";
-        var path = path.replace('//', '/');
-        var suffix = ".git";
-    
-        $('#repository_identifier').on('keyup', function() {
-            $('#repository_url').val(path + $(this).val() + suffix);
-        });
-        
-        if($('#repository_url').val() == '') {
-            $('#repository_url').val(path + '<REPO IDENTIFIER>' + suffix);
-        }
-    </script>
+            $('#repository_identifier').on('keyup', function() {
+                $('#repository_url').val(path + $(this).val() + suffix);
+            });
+
+            if($('#repository_url').val() == '') {
+                $('#repository_url').val(path + '<REPO IDENTIFIER>' + suffix);
+            }
+        </script>
+    <% end %>
 <% end %>
 
 <p>

--- a/app/views/settings/_gitdownload.html.erb
+++ b/app/views/settings/_gitdownload.html.erb
@@ -5,17 +5,48 @@
 <% content_for :header_tags do %>
     
 <% end %>
+
+<script type="text/javascript">
+function updateRemoteRelatedElementsEnableStatus() {
+  var value = document.querySelector("#settings_git_repo_is_remote").checked;
+  if (value == true) {
+    $("#settings_git_show_repourl").prop("disabled", false);
+    $("#git_url").prop("disabled", false);
+    $("#git_archive_last").prop("disabled", false);
+    $("#git_repo_create_path").prop("disabled", false);
+    $("#settings_git_auto_create_repo").prop("disabled", false);
+    $("#git_configfile").prop("disabled", false);
+    $("#git_copyfiles").prop("disabled", false);
+  } else {
+    $("#settings_git_show_repourl").prop("disabled", true);
+    $("#git_url").prop("disabled", true);
+    $("#git_archive_last").prop("disabled", true);
+    $("#git_repo_create_path").prop("disabled", true);
+    $("#settings_git_auto_create_repo").prop("disabled", true);
+    $("#git_configfile").prop("disabled", true);
+    $("#git_copyfiles").prop("disabled", true);
+  }
+  // unchecked by default
+  $("#settings_git_show_repourl").prop("checked", false);
+}
+$(document).on("page:load ready", updateRemoteRelatedElementsEnableStatus);
+</script>
+
 	<p>
-		<label for="git_url"><%= l(:label_gitdownload_host) %></label>
-	    <input style="width: 300px;" type="text" id="git_url" value="<%= settings["git_url"] %>" name="settings[git_url]" >
+		<label for="git_show_revs"><%= l(:git_show_revs) %></label>
+	    <%= check_box_tag "settings[git_show_revs]", settings['git_show_revs'], @settings['git_show_revs'] %>
 	</p>
+        <p>
+                <label for="git_repo_is_remote"><%= l(:git_repo_is_remote) %></label>
+                <%= check_box_tag "settings[git_repo_is_remote]", settings['git_repo_is_remote'], @settings['git_repo_is_remote'], :onclick=>"updateRemoteRelatedElementsEnableStatus();" %>
+        </p>
 	<p>
 		<label for="git_show_repourl"><%= l(:git_show_repourl) %></label>
 		<%= check_box_tag "settings[git_show_repourl]", settings['git_show_repourl'], @settings['git_show_repourl'] %>
 	</p>
 	<p>
-		<label for="git_show_revs"><%= l(:git_show_revs) %></label>
-	    <%= check_box_tag "settings[git_show_revs]", settings['git_show_revs'], @settings['git_show_revs'] %>
+		<label for="git_url"><%= l(:label_gitdownload_host) %></label>
+	    <input style="width: 300px;" type="text" id="git_url" value="<%= settings["git_url"] %>" name="settings[git_url]" >
 	</p>
 	<p>
 		<label for="git_archive_last"><%= l(:git_archive_last) %></label>

--- a/app/views/settings/_gitdownload.html.erb
+++ b/app/views/settings/_gitdownload.html.erb
@@ -34,43 +34,43 @@ $(document).on("page:load ready", updateRemoteRelatedElementsEnableStatus);
 
 	<p>
 		<label for="git_show_revs"><%= l(:git_show_revs) %></label>
-	    <%= check_box_tag "settings[git_show_revs]", settings['git_show_revs'], @settings['git_show_revs'] %>
+	    <%= check_box_tag "settings[git_show_revs]", Setting.plugin_gitdownload['git_show_revs'], Setting.plugin_gitdownload['git_show_revs'] %>
 	</p>
         <p>
                 <label for="git_repo_is_remote"><%= l(:git_repo_is_remote) %></label>
-                <%= check_box_tag "settings[git_repo_is_remote]", settings['git_repo_is_remote'], @settings['git_repo_is_remote'], :onclick=>"updateRemoteRelatedElementsEnableStatus();" %>
+                <%= check_box_tag "settings[git_repo_is_remote]", Setting.plugin_gitdownload['git_repo_is_remote'], Setting.plugin_gitdownload['git_repo_is_remote'], :onclick=>"updateRemoteRelatedElementsEnableStatus();" %>
         </p>
 	<p>
 		<label for="git_show_repourl"><%= l(:git_show_repourl) %></label>
-		<%= check_box_tag "settings[git_show_repourl]", settings['git_show_repourl'], @settings['git_show_repourl'] %>
+		<%= check_box_tag "settings[git_show_repourl]", Setting.plugin_gitdownload['git_show_repourl'], Setting.plugin_gitdownload['git_show_repourl'] %>
 	</p>
 	<p>
 		<label for="git_url"><%= l(:label_gitdownload_host) %></label>
-	    <input style="width: 300px;" type="text" id="git_url" value="<%= settings["git_url"] %>" name="settings[git_url]" >
+	    <input style="width: 300px;" type="text" id="git_url" value="<%= Setting.plugin_gitdownload["git_url"] %>" name="settings[git_url]" >
 	</p>
 	<p>
 		<label for="git_archive_last"><%= l(:git_archive_last) %></label>
-	    <input type="text" id="git_archive_last" value="<%= settings["git_archive_last"] %>" name="settings[git_archive_last]" >
+	    <input type="text" id="git_archive_last" value="<%= Setting.plugin_gitdownload["git_archive_last"] %>" name="settings[git_archive_last]" >
 	</p>
 	<p>
 		<label for="git_repo_create_path"><%= l(:git_repo_create_path) %></label>
-	    <input style="width: 300px;" type="text" id="git_repo_create_path" value="<%= settings["git_repo_create_path"] %>" name="settings[git_repo_create_path]" >
+	    <input style="width: 300px;" type="text" id="git_repo_create_path" value="<%= Setting.plugin_gitdownload["git_repo_create_path"] %>" name="settings[git_repo_create_path]" >
 	</p>
 	<p>
 		<label for="git_auto_create_repo"><%= l(:git_auto_create_repo) %></label>
-		<%= check_box_tag "settings[git_auto_create_repo]", settings['git_auto_create_repo'], @settings['git_auto_create_repo'] %>
+		<%= check_box_tag "settings[git_auto_create_repo]", Setting.plugin_gitdownload['git_auto_create_repo'], Setting.plugin_gitdownload['git_auto_create_repo'] %>
 	</p>
 	<p>
 		<label for="git_configfile">
 		    <%= l(:git_configfile) %>
 		</label>
 	    <textarea rows="10" style="width: 300px;" type="text" id="git_configfile" name="settings[git_configfile]" >
-<% if settings["git_configfile"].blank? %>
+<% if Setting.plugin_gitdownload["git_configfile"].blank? %>
 [user]
     name = Your Name
     email = you@example.com
 <% else %>
-<%= settings["git_configfile"] %>
+<%= Setting.plugin_gitdownload["git_configfile"] %>
 <% end %></textarea>
 	    <em class="info">
             <b><%= l(:git_configfile_info) %></b><br>
@@ -81,7 +81,7 @@ $(document).on("page:load ready", updateRemoteRelatedElementsEnableStatus);
 	</p>
 	<p>
 		<label for="git_copyfiles"><%= l(:git_copyfiles) %></label>
-	    <input style="width: 300px;" type="text" id="git_copyfiles" value="<%= settings["git_copyfiles"] %>" name="settings[git_copyfiles]" >
+	    <input style="width: 300px;" type="text" id="git_copyfiles" value="<%= Setting.plugin_gitdownload["git_copyfiles"] %>" name="settings[git_copyfiles]" >
 	    <em class="info">
             <b><%= l(:git_copyfiles_info) %></b>
         </em>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
   git_show_repourl: "Show repository URL"
   git_show_branch: "Allow branch download"
   git_show_revs: "Allow revision download"
+  git_repo_is_remote: "Using remote repositories"
   git_archive_last: "Delete files older than (min)"
   git_details: "Repository export details"
   field_repository_create: "Create Repository"

--- a/init.rb
+++ b/init.rb
@@ -12,14 +12,15 @@ Redmine::Plugin.register :gitdownload do
   version '0.0.1'
   url 'http://example.com/path/to/plugin'
   author_url 'http://example.com/about'
-  
+
   permission :commit_access, :gitdownload => :index
-  
+
   settings :default => {'git_url' => 'http://your.git.url/git/',
-               'git_show_repourl' => "on",
+               'git_show_repourl' => "off",
                'git_show_branch' => "on",
                'git_show_revs' => "on",
-  		'git_archive_last' => "10"}, :partial => 'settings/gitdownload'
+               'git_archive_last' => "10",
+               'git_repo_is_remote' => "off"}, :partial => 'settings/gitdownload'
 end
 
 

--- a/lib/gitdownload/repositories_controller_patch.rb
+++ b/lib/gitdownload/repositories_controller_patch.rb
@@ -14,89 +14,90 @@ module RepositoriesControllerPatch
   module InstanceMethods
 
       def create_with_patch
-        
+
         if params[:repository_scm] == 'Git'
-        
+
             @repository = Repository.factory(params[:repository_scm])
             @repository.safe_attributes = params[:repository]
             @repository.project = @project
-            
-            
+
+
             if request.post? && @repository.save
-    
-                # WRITE .gitconfig FILE TO USE WITH THE GIT COMMANDS
-                configContent = Setting.plugin_gitdownload["git_configfile"]
-                configContent.gsub! /\r\n?/, "\n"
-        
-                configDir = "#{Rails.root}/plugins/gitdownload/"
-                configFile = "#{configDir}.gitconfig"
-                
-                out_file = File.new("#{configFile}", "w")
-                out_file.puts("#{configContent}")
-                out_file.close 
-                
-                # CREATE REPOSITORY
-                git = "#{Redmine::Configuration['scm_git_command']}"
-                git = "git" if git.empty?
-                git = "HOME=#{configDir} " + git
-                path = params[:repository][:url]
-                storage = "#{Rails.root}/tmp/git/"
-                
-                FileUtils.mkdir_p(path) unless File.exists?(path)
-                Dir.chdir(path) do
-                    system "#{git} --bare init --shared"
-                    system "#{git} update-server-info"
-                end
-        
-                # CLONE REPOSITORY TO ./tmp/git/repo_*
-                repo_init = "#{storage}repo_#{@repository.identifier}"
-                FileUtils.mkdir_p(repo_init) unless File.exists?(repo_init)
-                Dir.chdir(storage) do
-                    clone = system "#{git} clone #{path} repo_#{@repository.identifier}"
-                    if clone == true
-                        logger.info "[#{Time.now}] - Git: cloned repo #{path} to #{repo_init}"
-                    else
-                        logger.info "[#{Time.now}] - Git: could not clone repo #{path} to #{repo_init}"
+                if Setting.plugin_gitdownload["git_repo_is_remote"] == "on"
+                    # WRITE .gitconfig FILE TO USE WITH THE GIT COMMANDS
+                    configContent = Setting.plugin_gitdownload["git_configfile"]
+                    configContent.gsub! /\r\n?/, "\n"
+
+                    configDir = "#{Rails.root}/plugins/gitdownload/"
+                    configFile = "#{configDir}.gitconfig"
+
+                    out_file = File.new("#{configFile}", "w")
+                    out_file.puts("#{configContent}")
+                    out_file.close
+
+                    # CREATE REPOSITORY
+                    git = "#{Redmine::Configuration['scm_git_command']}"
+                    git = "git" if git.empty?
+                    git = "HOME=#{configDir} " + git
+                    path = params[:repository][:url]
+                    storage = "#{Rails.root}/tmp/git/"
+
+                    FileUtils.mkdir_p(path) unless File.exists?(path)
+                    Dir.chdir(path) do
+                        system "#{git} --bare init --shared"
+                        system "#{git} update-server-info"
                     end
-        
-                end
-        
-                # INIT REPO WITH CUSTOM FILES, ADD, COMMIT, PUSH TO REMOTE
-                Dir.chdir(repo_init) do
-                    
-                    copyFiles = Setting.plugin_gitdownload["git_copyfiles"].strip
-                    if copyFiles.blank?
-                        out_file = File.new("init_repo.txt", "w")
-                        out_file.puts("Repository: #{path}")
-                        out_file.close 
-                    else
-                        FileUtils.cp_r "#{copyFiles}/.", "#{repo_init}"
+
+                    # CLONE REPOSITORY TO ./tmp/git/repo_*
+                    repo_init = "#{storage}repo_#{@repository.identifier}"
+                    FileUtils.mkdir_p(repo_init) unless File.exists?(repo_init)
+                    Dir.chdir(storage) do
+                        clone = system "#{git} clone #{path} repo_#{@repository.identifier}"
+                        if clone == true
+                            logger.info "[#{Time.now}] - Git: cloned repo #{path} to #{repo_init}"
+                        else
+                            logger.info "[#{Time.now}] - Git: could not clone repo #{path} to #{repo_init}"
+                        end
+
                     end
-        
-                    add = system "#{git} add ."
-                    if add == true
-                        logger.info "[#{Time.now}] - Git: files added #{path}"
-                    else
-                        logger.info "[#{Time.now}] - Git: could not add files #{path}"
+
+                    # INIT REPO WITH CUSTOM FILES, ADD, COMMIT, PUSH TO REMOTE
+                    Dir.chdir(repo_init) do
+
+                        copyFiles = Setting.plugin_gitdownload["git_copyfiles"].strip
+                        if copyFiles.blank?
+                            out_file = File.new("init_repo.txt", "w")
+                            out_file.puts("Repository: #{path}")
+                            out_file.close
+                        else
+                            FileUtils.cp_r "#{copyFiles}/.", "#{repo_init}"
+                        end
+
+                        add = system "#{git} add ."
+                        if add == true
+                            logger.info "[#{Time.now}] - Git: files added #{path}"
+                        else
+                            logger.info "[#{Time.now}] - Git: could not add files #{path}"
+                        end
+
+                        commit = system "#{git} commit -m 'Init Commit ...' && #{git} push origin master"
+                        if commit == true
+                            logger.info "[#{Time.now}] - Git: files pushed to repo #{path}"
+                        else
+                            logger.info "[#{Time.now}] - Git: could not commit and push files #{path}"
+                        end
+
+                        FileUtils.rm_rf(repo_init)
                     end
-        
-                    commit = system "#{git} commit -m 'Init Commit ...' && #{git} push origin master"
-                    if commit == true
-                        logger.info "[#{Time.now}] - Git: files pushed to repo #{path}"
-                    else
-                        logger.info "[#{Time.now}] - Git: could not commit and push files #{path}"
-                    end            
-        
-                    FileUtils.rm_rf(repo_init)
                 end
-    
+
                 redirect_to settings_project_path(@project, :tab => 'repositories')
             else
                 render :action => 'new'
             end
         end
       end
-        
+
   end
 end
 


### PR DESCRIPTION
1. Add "Using remote repositories" option to disable remote related settings
2. Reorder the settings so settings under "Using remote repositories"'s control are below it
3. git_repo_is_remote is default off so git_show_repourl should be default off too
4. Using javascript to dynamically enable/disable remote related settings
5. settings_git_show_repourl should be unchecked after settings_git_repo_is_remote is clicked

This completes #14.