### PR TITLE
Show tooltip when revisions div is disabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,2 @@
 gem 'rack-cors'
+gem 'i18n-js'

--- a/app/views/hooks/gitdownload/_view_repositories_show_contextual.erb
+++ b/app/views/hooks/gitdownload/_view_repositories_show_contextual.erb
@@ -1,5 +1,7 @@
 <!--FIXME: workaround for User.current is anonymous-->
 <!--% if User.current.allowed_to?(:commit_access, @project) %-->
+<%= javascript_include_tag "i18n" %>
+<%= javascript_include_tag "translations" %>
 <% if true %>
 	<div id="git-icon" class="git-icon"></div>
 		
@@ -49,7 +51,7 @@
                         <!--% if authorize_for('repositories', 'revisions') %-->
                         <% if true %>
 				<% if @changesets && !@changesets.empty? %>
-					<div id="revs" class="revs" title="Please switch to empty branch before choosing a revision" rel="tooltip">
+                                       <div id="revs" class="revs" title="<%= l(:git_revisions_tooltip) %>" rel="tooltip">
 						<h3><%= l(:label_latest_revision_plural) %></h3>
 						
 						<%= render :partial => 'gitrevisions',

--- a/app/views/hooks/gitdownload/_view_repositories_show_contextual.erb
+++ b/app/views/hooks/gitdownload/_view_repositories_show_contextual.erb
@@ -51,7 +51,7 @@
                         <!--% if authorize_for('repositories', 'revisions') %-->
                         <% if true %>
 				<% if @changesets && !@changesets.empty? %>
-                                       <div id="revs" class="revs" title="<%= l(:git_revisions_tooltip) %>" rel="tooltip">
+					<div id="revs" class="revs" title="<%= l(:git_revisions_tooltip) %>" rel="tooltip">
 						<h3><%= l(:label_latest_revision_plural) %></h3>
 						
 						<%= render :partial => 'gitrevisions',

--- a/app/views/hooks/gitdownload/_view_repositories_show_contextual.erb
+++ b/app/views/hooks/gitdownload/_view_repositories_show_contextual.erb
@@ -49,7 +49,7 @@
                         <!--% if authorize_for('repositories', 'revisions') %-->
                         <% if true %>
 				<% if @changesets && !@changesets.empty? %>
-					<div id="revs" class="revs">
+					<div id="revs" class="revs" title="Please switch to empty branch before choosing a revision" rel="tooltip">
 						<h3><%= l(:label_latest_revision_plural) %></h3>
 						
 						<%= render :partial => 'gitrevisions',

--- a/assets/javascripts/script.js
+++ b/assets/javascripts/script.js
@@ -76,9 +76,11 @@ $(function() {
         var valueSelected = this.value;
         if (valueSelected !== '') {
             $('#revs').addClass('disabled');
+            $('#revs').attr('title', 'Please switch to empty branch before choosing a revision').attr('rel', 'tooltip');
             $('#revs input').removeAttr('checked').attr('disabled', 'disabled');
         } else {
             $('#revs').removeClass('disabled');
+            $('#revs').removeAttr('title').removeAttr('rel');
             $('#revs input').removeAttr('disabled');
         }
     });

--- a/assets/javascripts/script.js
+++ b/assets/javascripts/script.js
@@ -76,7 +76,8 @@ $(function() {
         var valueSelected = this.value;
         if (valueSelected !== '') {
             $('#revs').addClass('disabled');
-            $('#revs').attr('title', 'Please switch to empty branch before choosing a revision').attr('rel', 'tooltip');
+            var tip = I18n.t('git_revisions_tooltip');
+            $('#revs').attr('title', tip).attr('rel', 'tooltip');
             $('#revs input').removeAttr('checked').attr('disabled', 'disabled');
         } else {
             $('#revs').removeClass('disabled');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,4 @@ en:
   git_copyfiles: "Add files to repository"
   git_configfile_info: "Minimum required config example:"
   git_copyfiles_info: "Copies the content of the given folder into the git repository (incl. dotfiles)"
+  git_revisions_tooltip: "Please switch to empty branch before choosing a revision"


### PR DESCRIPTION
By default, download branch is set as current branch and revisions div is disabled. For the first-time-users, it could be confusing why revisions div is disabled. This PR add a tooltip to guide users.

By hovering on revisions div, it will show following tooltip:
<img width="414" alt="image-20220325103429721" src="https://user-images.githubusercontent.com/18047300/160043616-583cbbf4-5e92-4701-a76e-73fa3cabbc91.png">

