### PR TITLE
[doc] remove gitdownload plugin folder on uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ cd /your/redmine/root/
 rake redmine:plugins:migrate NAME=gitdownload VERSION=0 RAILS_ENV=production
 ```
 
+_Delete gitdownload plugin directory:_
+
+```
+rm -rf /your/redmine/root/plugins/gitdownload
+```
+
 _Delete cors middleware:_
 
 ```


### PR DESCRIPTION
Sorry, missed this step for https://github.com/ochorocho/gitdownload/pull/18.